### PR TITLE
修复 添加删除障碍物后可能导致障碍物数据错乱

### DIFF
--- a/Assets/RVO2/Simulator.cs
+++ b/Assets/RVO2/Simulator.cs
@@ -1347,6 +1347,16 @@ namespace RVO
                         // so the old obstaclesPtr value became invalid and we have to assign again.
                         Obstacle* newObstacle = this.NewObstacleVert(splitPoint, obstacleJ1->obstacle);
                         obstaclesPtr = (Obstacle*)this.obstacles.GetUnsafePtr();
+
+                        // 往NativeList中添加新元素可能导致NativeList扩容
+                        // NativeList扩容后,指针指向了新地址
+                        // 这时通过原指针计算出的其他指针还指向旧地址
+                        // 需要更新这些指针
+                        obstacleI1 = obstaclesPtr + obstacleI1Index;
+                        obstacleI2 = obstaclesPtr + obstacleI2Index;
+                        obstacleJ1 = obstaclesPtr + obstacleJ1Index;
+                        obstacleJ2 = obstaclesPtr + obstacleJ2Index;
+
                         var newObstacleIndex = newObstacle->id;
                         newObstacle->previousIndex = obstacleJ1Index;
                         newObstacle->nextIndex = obstacleJ2Index;


### PR DESCRIPTION
Interactive场景下随机开启关闭障碍物有概率出现卡死,报错,障碍物显示异常,某段边界障碍失效等情况
卡死重现方式
Interactive场景下依次点击关闭左下,右下,右上,左上的障碍物
再依次点击开启左上,右上,右下,左下的障碍物
点击鼠标移动,场景卡死
此时在Interactive.OnDrawGizmos函数的第二个while循环中断点可命中断点

问题原因见代码注释